### PR TITLE
Updated the code to ES6 version

### DIFF
--- a/server/pluginId.js
+++ b/server/pluginId.js
@@ -1,5 +1,5 @@
-const pluginPkg = require('../package.json');
+import pluginPkg from '../package.json';
 
 const pluginId = pluginPkg.name.replace(/^@notum-cz\/strapi-plugin-/i, '');
 
-module.exports = pluginId;
+export default pluginId;

--- a/server/services/core-api.js
+++ b/server/services/core-api.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const uuid = require("uuid");
+const { v4: uuid } = require("uuid");
 const _ = require("lodash");
 const { getService } = require("../utils");
 


### PR DESCRIPTION
This code uses import instead of require to import the package.json file, and export default instead of module.exports to export the pluginId variable. Additionally, it uses the const keyword to declare the pluginId variable instead of the var keyword used in the original code.